### PR TITLE
Make sqlite index names unique by prepending the table name

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -141,6 +141,21 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * Namespaces index with the table name, as sqlite requires unique index names per database
+     *
+     * {@inheritDoc}
+     */
+    public function getCreateIndexSQL(Index $index, $table)
+    {
+        if (!$index->isPrimary()) { // leave the primary index alone
+            $name = ($table instanceof Table ? $table->getName() : $table) . '_' . $index->getName();
+            $index = new Index($name, $index->getColumns(), $index->isUnique(), $index->isPrimary(), $index->getFlags(), $index->getOptions());
+        }
+
+        return parent::getCreateIndexSQL($index, $table);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Sqlite requires unique index names per database, rather than per-table like most other DBMS.

eg.
> [Doctrine\ORM\Tools\ToolsException]                                                                                                                                                   
  Schema-Tool failed with Error 'An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1 index Active already exists' while executing DDL: CREATE INDEX Active ON table (Active)

Prepending the table name to the index name guarantees this uniqueness.
